### PR TITLE
Add ETradeBroker and --etrade CLI flag for E*TRADE transactions

### DIFF
--- a/brokers/__init__.py
+++ b/brokers/__init__.py
@@ -1,1 +1,6 @@
 """Broker/exchange adapters — Strategy pattern for data sources."""
+
+from brokers.etrade import ETradeBroker
+from brokers.ibkr import IBKRBroker
+
+__all__ = ["IBKRBroker", "ETradeBroker"]

--- a/brokers/etrade.py
+++ b/brokers/etrade.py
@@ -1,0 +1,282 @@
+"""ETradeBroker — E*TRADE adapter (OAuth 1.0a REST API).
+
+Fetches account list and historical transactions via the E*TRADE v1 API.
+Requires a one-time interactive OAuth handshake (browser + verifier code).
+
+Environment variables:
+  ETRADE_PROD_API_KEY    — Consumer key from E*TRADE developer portal
+  ETRADE_PROD_SECRET_KEY — Consumer secret from E*TRADE developer portal
+
+Usage:
+  broker = ETradeBroker()
+  transactions = broker.fetch_transactions(since=date(2026, 1, 1))
+
+Reference:
+  https://apisb.etrade.com/docs/api/account/api-transaction-v1.html
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date, datetime
+from pathlib import Path
+from typing import Literal
+
+from dotenv import load_dotenv
+from rauth import OAuth1Service
+
+from brokers.base import BaseBroker
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CONSUMER_KEY: str = os.getenv("ETRADE_PROD_API_KEY", "")
+CONSUMER_SECRET: str = os.getenv("ETRADE_PROD_SECRET_KEY", "")
+ACCOUNT_ID_KEY: str = os.getenv("ETRADE_ACCOUNT_ID", "")
+
+BASE_URL = "https://api.etrade.com"
+
+JSON_HEADERS = {"Accept": "application/json"}
+
+ETRADE_TOKEN_FILE = Path("etrade_token.json")
+
+_ACTION_MAP: dict[str, str] = {
+    "Bought": "買",
+    "Sold": "賣",
+    "Dividend": "股利",
+}
+
+# ---------------------------------------------------------------------------
+# OAuth helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_oauth_service() -> OAuth1Service:
+    """Create the rauth OAuth1Service for E*TRADE."""
+    if not CONSUMER_KEY or not CONSUMER_SECRET:
+        raise RuntimeError(
+            "Missing ETRADE_PROD_API_KEY or ETRADE_PROD_SECRET_KEY in env."
+        )
+    return OAuth1Service(
+        name="etrade",
+        consumer_key=CONSUMER_KEY,
+        consumer_secret=CONSUMER_SECRET,
+        request_token_url=f"{BASE_URL}/oauth/request_token",
+        access_token_url=f"{BASE_URL}/oauth/access_token",
+        authorize_url="https://us.etrade.com/e/t/etws/authorize",
+    )
+
+
+def _interactive_authorize(service: OAuth1Service):
+    """Run the full OAuth 1.0a handshake (requires user interaction)."""
+    request_token, request_token_secret = service.get_request_token(
+        params={"oauth_callback": "oob"}
+    )
+
+    authorize_url = (
+        f"https://us.etrade.com/e/t/etws/authorize"
+        f"?key={CONSUMER_KEY}&token={request_token}"
+    )
+    print(f"\n  Open this URL to authorize E*TRADE:\n  {authorize_url}\n")
+
+    verifier = input("  Enter verifier code: ").strip()
+
+    session = service.get_auth_session(
+        request_token,
+        request_token_secret,
+        method="POST",
+        data={"oauth_verifier": verifier},
+    )
+
+    # Persist tokens for reuse
+    _save_token(session.access_token, session.access_token_secret)
+    return session
+
+
+def _save_token(access_token: str, access_secret: str) -> None:
+    """Save OAuth tokens to disk."""
+    ETRADE_TOKEN_FILE.write_text(
+        json.dumps(
+            {"access_token": access_token, "access_secret": access_secret},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    print(f"  Token saved to {ETRADE_TOKEN_FILE}")
+
+
+def _load_saved_session(service: OAuth1Service):
+    """Try to restore a session from saved tokens. Returns session or None."""
+    if not ETRADE_TOKEN_FILE.exists():
+        return None
+
+    data = json.loads(ETRADE_TOKEN_FILE.read_text(encoding="utf-8"))
+    access_token = data.get("access_token", "")
+    access_secret = data.get("access_secret", "")
+    if not access_token or not access_secret:
+        return None
+
+    session = service.get_session((access_token, access_secret))
+
+    # Quick validation — if the token is expired E*TRADE returns 401
+    res = session.get(f"{BASE_URL}/v1/accounts/list", headers=JSON_HEADERS)
+    if res.ok:
+        print("  Reusing saved E*TRADE token.")
+        return session
+
+    print("  Saved token expired or revoked — re-authorising...")
+    ETRADE_TOKEN_FILE.unlink(missing_ok=True)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Transaction mapper
+# ---------------------------------------------------------------------------
+
+
+def _map_transaction(txn: dict) -> dict | None:
+    """Map a single E*TRADE transaction dict to CSV_FIELDNAMES dict.
+
+    E*TRADE field    → CSV column
+    --------------     ----------
+    transactionDate  → 交易日期  (epoch int64 → YYYY/M/D)
+    category         → 買/賣/股利
+    brokerage.product.symbol → 代號
+    description      → 股票
+    amount           → 收入 / 支出
+    brokerage.quantity → 買入股數 / 賣出股數
+    brokerage.price    → 買入價格 / 賣出價格
+    brokerage.commission → 手續費
+    """
+    raw_date = txn.get("transactionDate", 0)
+    if isinstance(raw_date, (int, float)) and raw_date > 0:
+        dt = datetime.fromtimestamp(raw_date / 1000)
+        txn_date = dt.strftime("%Y/%m/%d")
+    else:
+        txn_date = str(raw_date)
+
+    txn_type = txn.get("transactionType", "")
+    description = txn.get("description", "")
+    amount = txn.get("amount", 0)
+
+    brokerage = txn.get("brokerage", {})
+    product = brokerage.get("product", {})
+    symbol = product.get("symbol", "")
+    qty = str(abs(int(brokerage.get("quantity", 0) or 0)))
+    price = str(brokerage.get("price", ""))
+    fee = str(brokerage.get("fee", 0) or 0)
+
+    action = _ACTION_MAP.get(txn_type)
+    if action is None:
+        return None
+    is_buy = action == "買"
+    is_sell = action == "賣"
+
+    return {
+        "交易日期": txn_date,
+        "買/賣/股利": action,
+        "代號": symbol,
+        "股票": symbol,
+        "交易類別": "US",
+        "買入股數": qty if is_buy else "",
+        "買入價格": price if is_buy else "",
+        "賣出股數": qty if is_sell else "",
+        "賣出價格": price if is_sell else "",
+        "現價": "",
+        "手續費": fee,
+        "折讓後手續費": "",
+        "交易稅": "",
+        "成交價金": "",
+        "交易成本": "",
+        "支出": str(abs(amount)) if is_buy else "",
+        "收入": str(abs(amount)) if (is_sell or action == "股利") else "",
+        "決策原因": "",
+        "手續費折數": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# ETradeBroker
+# ---------------------------------------------------------------------------
+
+
+class ETradeBroker(BaseBroker):
+    """E*TRADE data source via OAuth 1.0a REST API."""
+
+    name = "ETRADE"
+    source_type: Literal["api"] = "api"
+
+    def __init__(self) -> None:
+        self._service = _build_oauth_service()
+        self._session = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_session(self) -> None:
+        """Authenticate: reuse saved token if valid, otherwise interactive flow."""
+        if self._session is None:
+            self._session = _load_saved_session(self._service)
+        if self._session is None:
+            self._session = _interactive_authorize(self._service)
+
+    def _get(self, path: str, params: dict | None = None):
+        """Issue a GET to the E*TRADE v1 API with JSON accept header."""
+        res = self._session.get(
+            f"{BASE_URL}{path}", headers=JSON_HEADERS, params=params
+        )
+        if not res.ok:
+            print(f"  E*TRADE {path} → HTTP {res.status_code}: {res.text}")
+        return res
+
+    def _list_accounts(self) -> list[dict]:
+        """Return ACTIVE accounts from /v1/accounts/list."""
+        res = self._get("/v1/accounts/list")
+        if not res.ok or not res.text.strip():
+            return []
+
+        accounts = (
+            res.json()
+            .get("AccountListResponse", {})
+            .get("Accounts", {})
+            .get("Account", [])
+        )
+        active = [a for a in accounts if a.get("accountStatus") == "ACTIVE"]
+        for a in active:
+            print(f"  Account: {a.get('accountDesc')} ({a.get('accountIdKey')})")
+        return active
+
+    def _fetch_account_transactions(
+        self, account_id_key: str, start: date
+    ) -> list[dict]:
+        """Fetch transactions for one account since *start*."""
+        start_str = start.strftime("%m%d%Y")  # E*TRADE date format: MMDDYYYY
+        res = self._get(
+            f"/v1/accounts/{account_id_key}/transactions",
+            params={"startDate": start_str},
+        )
+        if not res.ok or not res.text.strip():
+            return []
+
+        return res.json().get("TransactionListResponse", {}).get("Transaction", [])
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def fetch_transactions(self, since: date) -> list[dict]:
+        """Fetch historical transactions for the configured E*TRADE account."""
+        if not ACCOUNT_ID_KEY:
+            raise RuntimeError("Missing ETRADE_ACCOUNT_ID. Set it in your .env file.")
+
+        self._ensure_session()
+        print(f"  Account: {ACCOUNT_ID_KEY}")
+        raw = self._fetch_account_transactions(ACCOUNT_ID_KEY, since)
+        print(f"  {len(raw)} transaction(s)")
+
+        return [r for tx in raw if (r := _map_transaction(tx)) is not None]

--- a/brokers/ibkr.py
+++ b/brokers/ibkr.py
@@ -172,11 +172,19 @@ class IBKRBroker(BaseBroker):
     def _authenticate(self) -> None:
         """Wake up the Client Portal session; auto-resolve account ID if unset."""
         res = self._get("/iserver/accounts")
+        if not res.ok:
+            raise SystemExit(
+                f"❌ IBKR gateway unreachable (HTTP {res.status_code}). "
+                f"Please log in at {self.base_url.replace('/v1/api', '')} first."
+            )
+
         if not self.account:
-            accounts = res.json().get("accounts", []) if res.ok else []
+            accounts = res.json().get("accounts", [])
             if accounts:
                 self.account = accounts[0]
                 print(f"  Resolved IBKR account: {self.account}")
+            else:
+                print("  ❌ No accounts returned. Check gateway credentials.")
 
     def _fetch_conid_transactions(
         self, conid: int, days: int, symbol: str

--- a/config.py
+++ b/config.py
@@ -50,6 +50,24 @@ BROKER_CONFIG: dict[str, dict[str, str]] = {
 }
 
 # ---------------------------------------------------------------------------
+# API-based broker configuration
+# ---------------------------------------------------------------------------
+
+API_BROKER_CONFIG: dict[str, dict[str, str]] = {
+    "ETRADE": {
+        "api_key_env": "ETRADE_PROD_API_KEY",
+        "secret_key_env": "ETRADE_PROD_SECRET_KEY",
+        "account_env": "ETRADE_ACCOUNT_ID",
+    },
+    "IBKR": {
+        "host_env": "IBKR_HOST",
+        "port_env": "IBKR_PORT",
+        "account_env": "IBKR_ACCOUNT",
+        "watchlist_env": "IBKR_WATCHLIST_ID",
+    },
+}
+
+# ---------------------------------------------------------------------------
 # Credit-card bank configuration
 # ---------------------------------------------------------------------------
 

--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 """CLI entry point for the integrated-asset pipeline.
 
 Usage:
-  python main.py                    # run all stock stages
+  python main.py                    # run all stock stages (fetch -> decrypt -> analyze)
   python main.py --card             # run all card stages
   python main.py --fetch            # stock fetch only
   python main.py --since 10         # custom date range (days ago)
   python main.py --sync             # stock sync to Google Sheets only
   python main.py --ibkr             # fetch from IBKR Client Portal API
+  python main.py --etrade           # fetch from E*TRADE REST API
 """
 
 from __future__ import annotations
@@ -27,6 +28,10 @@ def _parse_args() -> argparse.Namespace:
             "  python main.py --card                   # credit card pipeline\n"
             "  python main.py --card --analyze         # card analyze only\n"
             "  python main.py --sync                   # sync CSV to Google Sheet\n"
+            "  python main.py --ibkr                   # fetch from IBKR Client Portal API\n"
+            "  python main.py --ibkr --since 30        # IBKR transactions from last 30 days\n"
+            "  python main.py --etrade                 # fetch from E*TRADE REST API\n"
+            "  python main.py --etrade --since 90      # E*TRADE transactions from last 90 days\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -65,6 +70,11 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Stage 5: Fetch transactions from IBKR Client Portal API",
     )
+    parser.add_argument(
+        "--etrade",
+        action="store_true",
+        help="Stage 6: Fetch transactions from E*TRADE REST API (OAuth 1.0a)",
+    )
     return parser.parse_args()
 
 
@@ -95,7 +105,12 @@ def main() -> None:
 
         pipeline = StockPipeline()
         run_all = not (
-            args.fetch or args.decrypt or args.analyze or args.sync or args.ibkr
+            args.fetch
+            or args.decrypt
+            or args.analyze
+            or args.sync
+            or args.ibkr
+            or args.etrade
         )
 
         if run_all:
@@ -116,6 +131,9 @@ def main() -> None:
             if args.ibkr:
                 print("=== Stage 5: Fetching from IBKR ===")
                 pipeline.fetch_ibkr(since=args.since)
+            if args.etrade:
+                print("=== Stage 6: Fetching from E*TRADE ===")
+                pipeline.fetch_etrade(since=args.since)
 
 
 if __name__ == "__main__":

--- a/pipelines/card.py
+++ b/pipelines/card.py
@@ -86,7 +86,11 @@ class CardPipeline(BasePipeline):
 
             # Extract statement month from filename (decrypted_YYYY-MM-DD_...)
             month_match = re.search(r"(\d{4})-(\d{2})-\d{2}", file.name)
-            stmt_month = f"{month_match.group(1)}-{month_match.group(2)}" if month_match else "unknown"
+            stmt_month = (
+                f"{month_match.group(1)}-{month_match.group(2)}"
+                if month_match
+                else "unknown"
+            )
 
             prompt = template.replace("{BANK_NAME}", bank_name)
 
@@ -220,9 +224,7 @@ class CardPipeline(BasePipeline):
                 write_csv(summary_path, summary_rows, SUMMARY_CSV_FIELDNAMES)
 
             print(
-                f"  {month_key}/  "
-                f"{len(merged)} total txns, "
-                f"{len(amounts)} new bank(s)"
+                f"  {month_key}/  {len(merged)} total txns, {len(amounts)} new bank(s)"
             )
 
         print(f"Monthly output → {monthly_dir}/")

--- a/pipelines/stock.py
+++ b/pipelines/stock.py
@@ -27,6 +27,7 @@ from utils.csv_helpers import (
 )
 from utils.patterns import load_processed, match_pattern, save_processed
 
+from brokers.etrade import ETradeBroker
 from brokers.ibkr import IBKRBroker
 
 # ---------------------------------------------------------------------------
@@ -257,6 +258,43 @@ class StockPipeline(BasePipeline):
 
         if not new_rows:
             print("No IBKR transactions returned.")
+            return
+
+        print(f"  {len(new_rows)} transaction(s) received.")
+        all_rows = read_existing_csv(self.csv_output) + new_rows
+        all_rows = [r for r in all_rows if any(str(v).strip() for v in r.values())]
+        all_rows = normalize_rows(all_rows, overflow_field="收入")
+        unique_rows = dedup_and_sort(
+            all_rows,
+            self.csv_fieldnames,
+            sort_key=lambda r: (
+                r.get("交易日期", ""),
+                r.get("代號", ""),
+                r.get("買/賣/股利", ""),
+            ),
+        )
+        write_csv(self.csv_output, unique_rows, self.csv_fieldnames)
+        dupes = len(all_rows) - len(unique_rows)
+        print(
+            f"Saved {self.csv_output} ({len(unique_rows)} rows, {dupes} dupes removed)"
+        )
+
+    # ------------------------------------------------------------------
+    # Stage 6 — E*TRADE API fetch
+    # ------------------------------------------------------------------
+
+    def fetch_etrade(self, since: int | None = None) -> None:
+        """Fetch transactions from E*TRADE REST API and merge into transactions.csv."""
+
+        days_back = since if since is not None else 30
+        since_date = date.today() - timedelta(days=days_back)
+
+        print(f"Fetching E*TRADE transactions since {since_date} ...")
+        broker = ETradeBroker()
+        new_rows = broker.fetch_transactions(since=since_date)
+
+        if not new_rows:
+            print("No E*TRADE transactions returned.")
             return
 
         print(f"  {len(new_rows)} transaction(s) received.")


### PR DESCRIPTION
Introduce the ETradeBroker for fetching transactions from the E*TRADE REST API, including OAuth 1.0a authentication and token persistence. Implement a new CLI flag `--etrade` to allow users to fetch transactions directly from E*TRADE, while filtering out non-trade transactions and ensuring date formats are consistent. Enhance error handling in the IBKR broker and centralize API broker configurations.

Fixes #27