### PR TITLE
Card pipeline: add rebuild command and fix prompt file names

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,22 +30,22 @@ BROKER_CONFIG: dict[str, dict[str, str]] = {
     "CATHAY_US": {
         "pattern_env": "CATHAY_US",
         "password_env": "PDF_PASSWORD",
-        "prompt": "Cathay_US.md",
+        "prompt": "CathayUS.md",
     },
     "CATHAY_TW": {
         "pattern_env": "CATHAY_TW",
         "password_env": "PDF_PASSWORD",
-        "prompt": "Cathay_TW.md",
+        "prompt": "CathayTW.md",
     },
     "FUBON_US": {
         "pattern_env": "FUBON_US",
         "password_env": "FUBON_PDF_PASSWORD",
-        "prompt": "Fubon_US.md",
+        "prompt": "FubonUS.md",
     },
     "TW_dividend": {
         "pattern_env": "TW_DIVIDEND",
         "password_env": "PDF_PASSWORD",
-        "prompt": "TW_Dividend.md",
+        "prompt": "TwDividend.md",
     },
 }
 

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ def _parse_args() -> argparse.Namespace:
             "  python main.py --analyze                # only Gemini analysis\n"
             "  python main.py --card                   # credit card pipeline\n"
             "  python main.py --card --analyze         # card analyze only\n"
+            "  python main.py --rebuild-card-all       # rebuild card aggregate CSV from monthly\n"
             "  python main.py --sync                   # sync CSV to Google Sheet\n"
             "  python main.py --ibkr                   # fetch IBKR transactions\n"
             "  python main.py --ibkr --since 30        # IBKR transactions from last 30 days\n"
@@ -48,6 +49,11 @@ def _parse_args() -> argparse.Namespace:
         "--card",
         action="store_true",
         help="Run credit-card pipeline instead of stock pipeline",
+    )
+    parser.add_argument(
+        "--rebuild-card-all",
+        action="store_true",
+        help="Rebuild attachments/card/credit_card_all.csv from attachments/card/monthly",
     )
     parser.add_argument(
         "--since",
@@ -82,11 +88,13 @@ def main() -> None:
     load_dotenv()
     args = _parse_args()
 
-    if args.card:
+    if args.card or args.rebuild_card_all:
         from pipelines.card import CardPipeline
 
         pipeline = CardPipeline()
-        run_all = not (args.fetch or args.decrypt or args.analyze)
+        run_all = not (
+            args.fetch or args.decrypt or args.analyze or args.rebuild_card_all
+        )
 
         if run_all:
             pipeline.run_all(
@@ -110,6 +118,11 @@ def main() -> None:
                     "Card Stage 3: Analyzing with Gemini",
                     pipeline.analyze,
                     debug=args.debug,
+                )
+            if args.rebuild_card_all:
+                pipeline.run_stage(
+                    "Card Utility: Rebuilding aggregate CSV",
+                    pipeline.rebuild_all,
                 )
     else:
         from pipelines.stock import StockPipeline

--- a/pipelines/card.py
+++ b/pipelines/card.py
@@ -29,7 +29,7 @@ from utils.patterns import load_processed, match_pattern, save_processed
 # ---------------------------------------------------------------------------
 
 CARD_DIR = ATTACHMENTS_DIR / "card"
-CARD_PROMPT_TEMPLATE = PROMPT_DIR / "Credit_Card.md"
+CARD_PROMPT_TEMPLATE = PROMPT_DIR / "CreditCard.md"
 
 
 class CardPipeline(BasePipeline):
@@ -132,28 +132,11 @@ class CardPipeline(BasePipeline):
             save_processed(processed, self.processed_file)
             return
 
-        # --- credit_card_all.csv ---
-        all_rows = read_existing_csv(self.csv_output) + new_rows
-        all_rows = [r for r in all_rows if any(str(v).strip() for v in r.values())]
-        all_rows = normalize_rows(all_rows)
-        unique_rows = dedup_and_sort(
-            all_rows,
-            self.csv_fieldnames,
-            sort_key=lambda r: (
-                r.get("交易日期", ""),
-                r.get("卡別", ""),
-                r.get("商店名稱", ""),
-            ),
-        )
+        new_rows = normalize_rows(new_rows)
 
-        write_csv(self.csv_output, unique_rows, self.csv_fieldnames)
-        dupes = len(all_rows) - len(unique_rows)
-        print(
-            f"\nSaved {self.csv_output} ({len(unique_rows)} rows, {dupes} dupes removed)"
-        )
-
-        save_processed(processed, self.processed_file)
+        # Monthly is the source of truth. Rebuild all from monthly outputs.
         self._monthly_split(new_rows, monthly_amounts)
+        save_processed(processed, self.processed_file)
 
     # ------------------------------------------------------------------
     # Card-specific helpers
@@ -227,6 +210,34 @@ class CardPipeline(BasePipeline):
             )
 
         print(f"Monthly output → {monthly_dir}/")
+
+    def rebuild_all(self) -> None:
+        """Rebuild credit_card_all.csv from monthly/*/credit_card.csv files."""
+        monthly_dir = CARD_DIR / "monthly"
+        if not monthly_dir.exists():
+            print(f"Monthly folder missing. Skip rebuilding {self.csv_output}.")
+            return
+
+        all_rows: list[dict] = []
+        for month_dir in sorted(d for d in monthly_dir.iterdir() if d.is_dir()):
+            cc_path = month_dir / "credit_card.csv"
+            all_rows.extend(read_existing_csv(cc_path))
+
+        all_rows = [r for r in all_rows if any(str(v).strip() for v in r.values())]
+        unique_rows = dedup_and_sort(
+            all_rows,
+            self.csv_fieldnames,
+            sort_key=lambda r: (
+                r.get("交易日期", ""),
+                r.get("卡別", ""),
+                r.get("商店名稱", ""),
+            ),
+        )
+        write_csv(self.csv_output, unique_rows, self.csv_fieldnames)
+        dupes = len(all_rows) - len(unique_rows)
+        print(
+            f"\nRebuilt {self.csv_output} from monthly ({len(unique_rows)} rows, {dupes} dupes removed)"
+        )
 
 
 def _parse_amount_due(text: str) -> str | None:

--- a/readme.md
+++ b/readme.md
@@ -29,8 +29,8 @@ flowchart TD
 
     card --> cardPdf["Gmail PDFs"]
     cardPdf --> cardGemini["Gemini analysis"]
-    cardGemini --> cardCsv["Credit card CSV"]
-    cardGemini --> cardMonthly["Monthly summary CSV"]
+    cardGemini --> cardMonthly["Monthly credit_card.csv + summary.csv"]
+    cardMonthly --> cardCsv["(Optional) Rebuild credit_card_all.csv"]
 
     crypto --> exchanges["OKX / Bitget / Binance"]
     exchanges --> cryptoCsv["Convert to CSV"]
@@ -145,6 +145,9 @@ python main.py --card
 python main.py --card --fetch
 python main.py --card --decrypt
 python main.py --card --analyze
+
+# Rebuild card aggregate CSV from monthly only
+python main.py --rebuild-card-all
 ```
 
 ### Crypto Pipeline
@@ -202,6 +205,9 @@ run_pipeline.bat
     └── card/
         ├── raw/                    # Downloaded card PDFs
         ├── decrypted/              # Decrypted card PDFs
-        ├── credit_card_all.csv     # All credit card transactions
-        └── monthly_summary.csv     # Monthly spending summary
-```
+        ├── monthly/                # Source of truth by statement month
+        │   └── YYYY-MM/
+        │       ├── credit_card.csv # Monthly transaction rows
+        │       └── summary.csv     # Monthly amount due by bank
+        └── credit_card_all.csv     # Rebuilt aggregate from monthly/*/credit_card.csv
+    ```


### PR DESCRIPTION
Enhance the credit card pipeline by introducing a command to rebuild the aggregate CSV from monthly files, ensuring that the monthly outputs serve as the source of truth. Update prompt file names for consistency and clarity.

Fixes #35